### PR TITLE
Fix selectors warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "universal-cookie": "^4.0.4"
   },
   "scripts": {
+    "dev": "vite",
     "start": "vite",
     "build": "tsc && vite build",
     "serve": "vite preview",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,16 @@ import SideBar from './components/SideBar/SideBar';
 import PlaylistDetail from './pages/PlaylistDetail/PlaylistDetail';
 import Playlists from './pages/Playlists/Playlists';
 import { useAppDispatch, useAppSelector } from './store/hooks';
-import { fetchFeaturedPlaylists } from './store/reducers/featuredPlaylists.slice';
+import {
+  fetchFeaturedPlaylists,
+  selectFeaturedPlaylists,
+} from './store/reducers/featuredPlaylists.slice';
 
 const App = () => {
   const cookies = new Cookies();
   const dispatch = useAppDispatch();
   const { playlists, message, loading, error } = useAppSelector(
-    (state) => state.featuredPlaylists,
+    selectFeaturedPlaylists,
   );
 
   useEffect(() => {

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -5,7 +5,10 @@ import { ReactComponent as Play } from '../../assets/play.svg';
 import { ReactComponent as Volume } from '../../assets/volume.svg';
 import { ReactComponent as VolumeMuted } from '../../assets/volumeMuted.svg';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { playPause } from '../../store/reducers/currentSong.slice';
+import {
+  playPause,
+  selectCurrentSong,
+} from '../../store/reducers/currentSong.slice';
 import msToMinutesAndSeconds from '../../utils/msToMinutes';
 import useBar from '../../utils/useBar';
 import useStopwatch from '../../utils/useStopwatch';
@@ -13,7 +16,7 @@ import styles from './Player.module.scss';
 
 const Player = () => {
   const dispatch = useAppDispatch();
-  const { song, playing } = useAppSelector((state) => state.currentSong);
+  const { song, playing } = useAppSelector(selectCurrentSong);
   const audioEml = useRef<HTMLAudioElement | null>(null);
 
   const timeRef = useRef<HTMLDivElement | null>(null);

--- a/src/pages/PlaylistDetail/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail/PlaylistDetail.tsx
@@ -6,7 +6,7 @@ import Loader from '../../components/Loader/Loader';
 import NotFound from '../../components/NotFound/NotFound';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
-  currentSongSelector,
+  selectCurrentSong,
   loadSong,
 } from '../../store/reducers/currentSong.slice';
 import {
@@ -23,7 +23,7 @@ const PlaylistDetail = () => {
   const coverRef = useRef<HTMLImageElement | null>(null);
   const dispatch = useAppDispatch();
   const { playlist, loading, error } = useAppSelector(playlistDetailsSelector);
-  const { song } = useAppSelector(currentSongSelector);
+  const { song } = useAppSelector(selectCurrentSong);
 
   useEffect(() => {
     if (id != null) {

--- a/src/pages/PlaylistDetail/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail/PlaylistDetail.tsx
@@ -5,8 +5,14 @@ import { ReactComponent as Time } from '../../assets/time.svg';
 import Loader from '../../components/Loader/Loader';
 import NotFound from '../../components/NotFound/NotFound';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { loadSong } from '../../store/reducers/currentSong.slice';
-import { fetchPlaylistById } from '../../store/reducers/playlistDetail.slice';
+import {
+  currentSongSelector,
+  loadSong,
+} from '../../store/reducers/currentSong.slice';
+import {
+  fetchPlaylistById,
+  playlistDetailsSelector,
+} from '../../store/reducers/playlistDetail.slice';
 import { Track } from '../../types/track.interface';
 import msToMinutesAndSeconds from '../../utils/msToMinutes';
 import styles from './PlaylistDetail.module.scss';
@@ -16,10 +22,8 @@ const PlaylistDetail = () => {
   const { id } = useParams<{ id: string }>();
   const coverRef = useRef<HTMLImageElement | null>(null);
   const dispatch = useAppDispatch();
-  const {
-    currentSong: { song },
-    playlistDetail: { playlist, loading, error },
-  } = useAppSelector((state) => state);
+  const { playlist, loading, error } = useAppSelector(playlistDetailsSelector);
+  const { song } = useAppSelector(currentSongSelector);
 
   useEffect(() => {
     if (id != null) {

--- a/src/store/reducers/currentSong.slice.ts
+++ b/src/store/reducers/currentSong.slice.ts
@@ -31,5 +31,3 @@ export const { loadSong, playPause } = currentSongSlice.actions;
 export default currentSongSlice;
 
 export const currentSongSelector = (state: RootState) => state.currentSong;
-export const songSelector = (state: RootState) => state.currentSong.song;
-export const playingSelector = (state: RootState) => state.currentSong.playing;

--- a/src/store/reducers/currentSong.slice.ts
+++ b/src/store/reducers/currentSong.slice.ts
@@ -30,7 +30,6 @@ export const { loadSong, playPause } = currentSongSlice.actions;
 
 export default currentSongSlice;
 
-export const songSelector = (state: RootState): Track | null =>
-  state.currentSong.song;
-export const playingSelector = (state: RootState): boolean =>
-  state.currentSong.playing;
+export const currentSongSelector = (state: RootState) => state.currentSong;
+export const songSelector = (state: RootState) => state.currentSong.song;
+export const playingSelector = (state: RootState) => state.currentSong.playing;

--- a/src/store/reducers/currentSong.slice.ts
+++ b/src/store/reducers/currentSong.slice.ts
@@ -30,4 +30,4 @@ export const { loadSong, playPause } = currentSongSlice.actions;
 
 export default currentSongSlice;
 
-export const currentSongSelector = (state: RootState) => state.currentSong;
+export const selectCurrentSong = (state: RootState) => state.currentSong;

--- a/src/store/reducers/featuredPlaylists.slice.ts
+++ b/src/store/reducers/featuredPlaylists.slice.ts
@@ -54,6 +54,5 @@ const featuredPlaylistSlice = createSlice({
 
 export default featuredPlaylistSlice;
 
-export const featuredPlaylistsSelector = (
-  state: RootState,
-): PlaylistsType | null => state.featuredPlaylists.playlists;
+export const featuredPlaylistsSelector = (state: RootState) =>
+  state.featuredPlaylists;

--- a/src/store/reducers/featuredPlaylists.slice.ts
+++ b/src/store/reducers/featuredPlaylists.slice.ts
@@ -54,5 +54,5 @@ const featuredPlaylistSlice = createSlice({
 
 export default featuredPlaylistSlice;
 
-export const featuredPlaylistsSelector = (state: RootState) =>
+export const selectFeaturedPlaylists = (state: RootState) =>
   state.featuredPlaylists;

--- a/src/store/reducers/playlistDetail.slice.ts
+++ b/src/store/reducers/playlistDetail.slice.ts
@@ -51,6 +51,5 @@ const playlistDetailSlice = createSlice({
 
 export default playlistDetailSlice;
 
-export const playlistDetailsSelector = (
-  state: RootState,
-): PlaylistType | null => state.playlistDetail.playlist;
+export const playlistDetailsSelector = (state: RootState) =>
+  state.playlistDetail;


### PR DESCRIPTION
Remove warning

_Selector unknown returned the root state when called. This can lead to unnecessary rerenders.
Selectors that return the entire state are almost certainly a mistake, as they will cause a rerender whenever *anything* in state changes._